### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Compare_pipelines.py
+++ b/Compare_pipelines.py
@@ -21,7 +21,7 @@ def _download_spec(fout):
     """
     import requests
     spec = fout.rpartition('/')[-1]
-    url = 'http://www.astro.up.pt/~dandreasen/%s' % spec
+    url = 'http://www.astro.up.pt/~dandreasen/{0!s}'.format(spec)
     spectrum = requests.get(url)
     with open(fout, 'w') as file:
         file.write(spectrum.content)
@@ -343,7 +343,7 @@ def main(fname, fname2, lines=False, model=False, telluric=False, sun=False,
             urllib.urlretrieve(url, pathwave)
     else:
         os.mkdir(path)
-        print('%s Created' % path)
+        print('{0!s} Created'.format(path))
         print('Downloading solar spectrum...')
         _download_spec(pathsun)
         print('Downloading telluric spectrum...')
@@ -608,21 +608,21 @@ def main(fname, fname2, lines=False, model=False, telluric=False, sun=False,
         ax3.set_xlabel('RV [km/s]')
 
     if rv:
-        ax1.set_title('%s\nRV correction: %s km/s' % (fname, rv))
+        ax1.set_title('{0!s}\nRV correction: {1!s} km/s'.format(fname, rv))
     elif rv1 and rv2:
-        ax1.set_title('%s\nSun/model: %s km/s, telluric: %s km/s' % (fname, rv1, rv2))
+        ax1.set_title('{0!s}\nSun/model: {1!s} km/s, telluric: {2!s} km/s'.format(fname, rv1, rv2))
     elif rv1 and not rv2:
-        ax1.set_title('%s\nSun/model: %s km/s' % (fname, rv1))
+        ax1.set_title('{0!s}\nSun/model: {1!s} km/s'.format(fname, rv1))
     elif not rv1 and rv2:
-        ax1.set_title('%s\nTelluric: %s km/s' % (fname, rv2))
+        ax1.set_title('{0!s}\nTelluric: {1!s} km/s'.format(fname, rv2))
     elif ccf == 'model':
-        ax1.set_title('%s\nModel(CCF): %s km/s' % (fname, rv1))
+        ax1.set_title('{0!s}\nModel(CCF): {1!s} km/s'.format(fname, rv1))
     elif ccf == 'sun':
-        ax1.set_title('%s\nSun(CCF): %s km/s' % (fname, rv1))
+        ax1.set_title('{0!s}\nSun(CCF): {1!s} km/s'.format(fname, rv1))
     elif ccf == 'telluric':
-        ax1.set_title('%s\nTelluric(CCF): %s km/s' % (fname, rv2))
+        ax1.set_title('{0!s}\nTelluric(CCF): {1!s} km/s'.format(fname, rv2))
     elif ccf == 'both':
-        ax1.set_title('%s\nSun/model(CCF): %s km/s, telluric(CCF): %s km/s' % (fname, rv1, rv2))
+        ax1.set_title('{0!s}\nSun/model(CCF): {1!s} km/s, telluric(CCF): {2!s} km/s'.format(fname, rv1, rv2))
     else:
         ax1.set_title(fname)
     if sun or telluric or model:

--- a/JobLib/Joblib_for_Daniel.py
+++ b/JobLib/Joblib_for_Daniel.py
@@ -31,7 +31,7 @@ def inside_loop(newatm, models, layer, column, gridpoints, teff_logg_feh):
     for inx, model in enumerate(models):
         tlayer[indx] = model[layer, column]
     #print(" for layer = {0}, column = {1}".format(layer, column))
-    print("[Worker %d] Layer %d and Column %d is about to griddata" % (os.getpid(), layer, column))
+    print("[Worker {0:d}] Layer {1:d} and Column {2:d} is about to griddata".format(os.getpid(), layer, column))
     newatm[layer,column] = griddata(gridpoints, tlayer, teff_logg_feh, method='linear', rescale=True)
     
 
@@ -144,7 +144,7 @@ from joblib import load, dump
 def sum_row(input, output, i):
     """Compute the sum of a row in input and store it in output"""
     sum_ = input[i, :].sum()
-    print("[Worker %d] Sum for row %d is %f" % (os.getpid(), i, sum_))
+    print("[Worker {0:d}] Sum for row {1:d} is {2:f}".format(os.getpid(), i, sum_))
     output[i] = sum_
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:equanimous-octo-tribble?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jason-neal:equanimous-octo-tribble?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)