### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/JobLib/Joblib_for_Daniel.py
+++ b/JobLib/Joblib_for_Daniel.py
@@ -37,7 +37,7 @@ def inside_loop(newatm, models, layer, column, gridpoints, teff_logg_feh):
     for inx, model in enumerate(models):
         tlayer[indx] = model[layer, column]
     #print(" for layer = {0}, column = {1}".format(layer, column))
-    print("[Worker %d] Layer %d and Column %d is about to griddata" % (os.getpid(), layer, column))
+    print("[Worker {0:d}] Layer {1:d} and Column {2:d} is about to griddata".format(os.getpid(), layer, column))
     newatm[layer,column] = griddata(gridpoints, tlayer, teff_logg_feh, method='linear', rescale=True)
     
 
@@ -134,7 +134,7 @@ finally:
 def sum_row(input, output, i):
     """Compute the sum of a row in input and store it in output"""
     sum_ = input[i, :].sum()
-    print("[Worker %d] Sum for row %d is %f" % (os.getpid(), i, sum_))
+    print("[Worker {0:d}] Sum for row {1:d} is {2:f}".format(os.getpid(), i, sum_))
     output[i] = sum_
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:equanimous-octo-tribble?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jason-neal:equanimous-octo-tribble?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)